### PR TITLE
Broke out some settings into variables instead.

### DIFF
--- a/misppull.py
+++ b/misppull.py
@@ -4,12 +4,23 @@ from pymemcache.client.base import Client
 import json
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-client = Client(('127.0.0.1', 11211)) #assumes local memcached application, if needed change this to suit your installation
+
+## The following settings are for your memcached installation.
+## Update them to fit your installation.
+MEMCACHED_HOST = '127.0.0.1'
+MEMCACHED_PORT = 11211
+
+## The following settings are for your MISP installation.
+## Update them to fit your installation
+MISP_URL = 'https://****INSERTYOURMISPADDRESSHERE****/attributes/restSearch'
+MISP_API_KEY = '****INSERTYOURMISPAPIKEYHERE****'
+
+client = Client((MEMCACHED_HOST, MEMCACHED_PORT))
 
 def misppull(dataType):
-  headers={'Authorization':'****INSERTYOURMISPAPIKEYHERE****','Accept':'application/json','Content-type':'application/json'}
+  headers={'Authorization':MISP_API_KEY,'Accept':'application/json','Content-type':'application/json'}
   data=json.dumps({"returnFormat":"json","type":dataType,"tags":"Feed-%","to_ids":"yes","includeEventTags":"yes","includeContext":"yes"})
-  response = requests.post('https://****INSERTYOURMISPADDRESSHERE****/attributes/restSearch',headers=headers,data=data,verify=False)
+  response = requests.post(MISP_URL,headers=headers,data=data,verify=False)
   return response
 
 


### PR DESCRIPTION
Hi,

Might be a bit over the top but I like to have things like API keys and URL's as variables. It sort of makes it easier for me to read and makes it less prone for tpyos and errors.

I've tested it in my end and it seems to work fine here.