### PR TITLE
Simple errorhandling

### DIFF
--- a/misppull.py
+++ b/misppull.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
   for dt in dataTypes:
     response = misppull(dt)
     data=response.json()
-    if data:
+    if 'response' in data:
       for item in data["response"]["Attribute"]:
         tagList=[]
         for tag in item['Tag']:

--- a/misppull.py
+++ b/misppull.py
@@ -4,12 +4,23 @@ from pymemcache.client.base import Client
 import json
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-client = Client(('127.0.0.1', 11211)) #assumes local memcached application, if needed change this to suit your installation
+
+## The following settings are for your memcached installation.
+## Update them to fit your installation.
+MEMCACHED_HOST = '127.0.0.1'
+MEMCACHED_PORT = 11211
+
+## The following settings are for your MISP installation.
+## Update them to fit your installation
+MISP_URL = 'https://****INSERTYOURMISPADDRESSHERE****/attributes/restSearch'
+MISP_API_KEY = '****INSERTYOURMISPAPIKEYHERE****'
+
+client = Client((MEMCACHED_HOST, MEMCACHED_PORT))
 
 def misppull(dataType):
-  headers={'Authorization':'****INSERTYOURMISPAPIKEYHERE****','Accept':'application/json','Content-type':'application/json'}
+  headers={'Authorization':MISP_API_KEY,'Accept':'application/json','Content-type':'application/json'}
   data=json.dumps({"returnFormat":"json","type":dataType,"tags":"Feed-%","to_ids":"yes","includeEventTags":"yes","includeContext":"yes"})
-  response = requests.post('https://****INSERTYOURMISPADDRESSHERE****/attributes/restSearch',headers=headers,data=data,verify=False)
+  response = requests.post(MISP_URL,headers=headers,data=data,verify=False)
   return response
 
 


### PR DESCRIPTION
Hi there,

I managed to break my Misp as well as generate some weird error messages when pulling via the API. This made me realise that the code exits out if the response from the server is not exactly what we're looking for.

I added some very rudimentary checking that stops this from happening. This could in theory be extended to catch errors like incorrect API key, 'error 500' and other things and possibly log that somewhere.

If this run as a cron job it could be useful to catch and log unsuccessful runs in order to be able to trust that memcached is actually being populated?